### PR TITLE
Add keyboard shortcuts support and help modal

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -20,6 +20,8 @@ import { useInfinitePagination } from "@/hooks/useInfinitePagination";
 import { FilterDropdown } from "@/components/filter-dropdown";
 import { useDebounce } from "use-debounce";
 import { DEFAULT_PAGE_SIZE, SEARCH_DEBOUNCE_DELAY } from "@/lib/constants";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function Home({
   sequenceId,
@@ -77,6 +79,26 @@ export default function Home({
     setSearchTerm("");
     setTimeFilter(undefined);
   };
+
+  useKeyboardShortcuts([
+    {
+      key: "n",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      onTrigger: () => setIsCreateDialogOpen(true),
+    },
+    {
+      key: "enter",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      onTrigger: () => {
+        const runButtons = document.querySelectorAll(
+          "[data-run-shortcut]"
+        ) as NodeListOf<HTMLButtonElement>;
+        runButtons?.[0]?.click();
+      },
+    },
+  ]);
 
   if (status === "loading") return <SessionLoader />;
 
@@ -139,6 +161,16 @@ export default function Home({
         </div>
         <div>
           <FilterDropdown value={timeFilter} onChange={setTimeFilter} />
+          <div className="mt-2 flex items-center gap-2 text-xs text-[#92a9c9]">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="cursor-help">⌘/Ctrl + Enter</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                {translate("shortcuts.actions.run")}
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       </div>
       <section className="mt-4 pb-24">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,8 @@ import { Theme } from "@radix-ui/themes";
 import { SessionProvider } from "next-auth/react";
 import { AuthStateSync } from "@/hooks/authStateSync";
 import { MobileMenu } from "@/components/mobile-menu";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { KeyboardShortcutsHelp } from "@/components/keyboard-shortcuts-help";
 
 type THEME = "dark" | "light";
 
@@ -18,6 +20,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const theme: THEME = "dark";
+
+  useKeyboardShortcuts([
+    {
+      key: "b",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      onTrigger: () => {
+        const event = new Event("toggle-sidebar");
+        window.dispatchEvent(event);
+      },
+    },
+  ]);
 
   return (
     <html lang="en" className={theme}>
@@ -32,6 +46,9 @@ export default function RootLayout({
                   <AuthStateSync />
                   <div className="relative">
                     <MobileMenu />
+                    <div className="absolute right-4 top-3 z-20">
+                      <KeyboardShortcutsHelp />
+                    </div>
                     {children}
                   </div>
                 </main>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/app/services/users";
 import { BIO_MAX_LENGTH } from "@/lib/constants";
 import { SessionLoader } from "@/components/ui/spinner";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export default function ProfilePage() {
   const { data: session } = useSession();
@@ -21,6 +23,21 @@ export default function ProfilePage() {
     { skip: !userId }
   );
   const [updateUser, { isLoading: isUpdatingBio }] = useUpdateUserMutation();
+
+  useKeyboardShortcuts(
+    [
+      {
+        key: "s",
+        modifier: "metaOrCtrl",
+        allowInInput: true,
+        onTrigger: () => {
+          const saveButton = document.getElementById("save-bio-button");
+          saveButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        },
+      },
+    ],
+    { enabled: true }
+  );
 
   const handleBioChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = e.target;
@@ -167,7 +184,18 @@ export default function ProfilePage() {
                   </div>
                 </div>
                 <div className="mt-2 flex items-center justify-end gap-3 border-t border-[#233348] pt-4">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="text-xs text-[#92a9c9] cursor-help">
+                        ⌘/Ctrl + S
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {translate("shortcuts.actions.save")}
+                    </TooltipContent>
+                  </Tooltip>
                   <Button
+                    id="save-bio-button"
                     className="flex items-center gap-2 rounded-lg bg-[#136dec] px-5 py-2.5 text-sm font-bold text-white shadow-lg shadow-blue-900/20 transition hover:bg-[#0f5dc9]"
                     type="submit"
                     loading={isUpdatingBio}

--- a/components/create-sequence-cta.tsx
+++ b/components/create-sequence-cta.tsx
@@ -2,6 +2,8 @@ import { FC, useState } from "react";
 import { translate } from "@/lib/i18n";
 import { IconButton, TextField } from "@radix-ui/themes";
 import { CircleArrowRight, Sparkles, X } from "lucide-react";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 interface Props {
   onCreate: (title: string) => void;
@@ -9,6 +11,21 @@ interface Props {
 
 export const CreateSequenceCta: FC<Props> = ({ onCreate }) => {
   const [sequenceTitle, setSequenceTitle] = useState("");
+
+  useKeyboardShortcuts([
+    {
+      key: "n",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      onTrigger: () => {
+        const hasTextSelected = window.getSelection()?.toString();
+        if (hasTextSelected) return;
+
+        const createButton = document.getElementById("create-sequence-shortcut");
+        createButton?.click();
+      },
+    },
+  ]);
 
   return (
     <div className="fixed bottom-6 left-0 z-20 w-full md:left-[256px] md:w-[calc(100%-256px)]">
@@ -35,6 +52,7 @@ export const CreateSequenceCta: FC<Props> = ({ onCreate }) => {
           </TextField.Root>
           <div className="flex items-center gap-2">
             <IconButton
+              id="create-sequence-shortcut"
               disabled={!sequenceTitle}
               type="button"
               size="3"
@@ -46,6 +64,16 @@ export const CreateSequenceCta: FC<Props> = ({ onCreate }) => {
             >
               <CircleArrowRight />
             </IconButton>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="text-xs text-[#1f2937] md:text-[#92a9c9] cursor-help">
+                  ⌘/Ctrl + N
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {translate("shortcuts.actions.newChain")}
+              </TooltipContent>
+            </Tooltip>
           </div>
         </div>
       </div>

--- a/components/keyboard-shortcuts-help.tsx
+++ b/components/keyboard-shortcuts-help.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { translate } from "@/lib/i18n";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Modal } from "@/components/ui/modal";
+import { Badge, Flex, Separator, Text } from "@radix-ui/themes";
+import { HelpCircle, Keyboard } from "lucide-react";
+import { ShortcutHint, useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+
+const KEYBOARD_SHORTCUT_HINTS = (): ShortcutHint[] => [
+  {
+    keys: ["N"],
+    label: translate("shortcuts.actions.newChain"),
+  },
+  {
+    keys: ["S"],
+    label: translate("shortcuts.actions.save"),
+  },
+  {
+    keys: ["Cmd/Ctrl", "Enter"],
+    label: translate("shortcuts.actions.run"),
+  },
+  {
+    keys: ["?"],
+    label: translate("shortcuts.actions.openHelp"),
+  },
+  {
+    keys: ["Cmd/Ctrl", "B"],
+    label: translate("shortcuts.actions.toggleSidebar"),
+  },
+];
+
+export function KeyboardShortcutsHelp() {
+  const [open, setOpen] = useState(false);
+
+  useKeyboardShortcuts(
+    [
+      {
+        key: "?",
+        allowInInput: true,
+        onTrigger: () => setOpen(true),
+      },
+    ],
+    { enabled: true }
+  );
+
+  const hintList = useMemo(KEYBOARD_SHORTCUT_HINTS, []);
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            data-shortcut-help
+            aria-label={translate("shortcuts.helpTooltip")}
+            className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm text-[#92a9c9] shadow-md transition hover:border-white/20 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          >
+            <HelpCircle className="h-5 w-5" aria-hidden />
+            <span className="hidden md:inline">{translate("shortcuts.title")}</span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{translate("shortcuts.helpTooltip")}</TooltipContent>
+      </Tooltip>
+
+      {open ? (
+        <Modal open={open} onOpenChange={setOpen}>
+          <Modal.Content className="max-w-lg rounded-2xl border border-white/10 bg-[#0f1723] p-6 shadow-2xl">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <Text size="6" weight="bold" className="text-white">
+                  {translate("shortcuts.title")}
+                </Text>
+                <Text size="2" color="gray">
+                  {translate("shortcuts.description")}
+                </Text>
+              </div>
+              <Modal.Close aria-label={translate("common.close")}>×</Modal.Close>
+            </div>
+
+            <Separator size="4" className="my-4 border-white/10" />
+
+            <div className="flex flex-col gap-3">
+              {hintList.map((hint) => (
+                <Flex
+                  key={hint.label}
+                  align="center"
+                  justify="between"
+                  className="rounded-lg border border-white/5 bg-white/5 px-3 py-2"
+                >
+                  <div className="flex items-center gap-2 text-white">
+                    <Keyboard className="h-4 w-4 text-primary" aria-hidden />
+                    <Text size="2" weight="medium">
+                      {hint.label}
+                    </Text>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {hint.keys.map((key) => (
+                      <Badge key={key} variant="soft" color="indigo" className="uppercase">
+                        {key}
+                      </Badge>
+                    ))}
+                  </div>
+                </Flex>
+              ))}
+            </div>
+          </Modal.Content>
+        </Modal>
+      ) : null}
+    </>
+  );
+}

--- a/components/studio-view.tsx
+++ b/components/studio-view.tsx
@@ -28,6 +28,8 @@ import { ViewSequence } from "./view-sequence";
 import { FilterDropdown } from "./filter-dropdown";
 import { CreateSequenceForm } from "./ui/create-sequence";
 import { DataLoader, SessionLoader } from "./ui/spinner";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 
 type StatCard = {
   icon: LucideIcon;
@@ -82,6 +84,27 @@ export function StudioView({
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [showCreationSuccess, setShowCreationSuccess] = useState(false);
   const currentSequenceId = useRef<number | string | null>(null);
+
+  useKeyboardShortcuts([
+    {
+      key: "enter",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      onTrigger: () => {
+        const runButtons = document.querySelectorAll(
+          "[data-run-shortcut]"
+        ) as NodeListOf<HTMLButtonElement>;
+        runButtons?.[0]?.click();
+      },
+    },
+    {
+      key: "n",
+      modifier: "metaOrCtrl",
+      allowInInput: true,
+      enabled: isMyStudio,
+      onTrigger: () => setIsCreateDialogOpen(true),
+    },
+  ]);
 
   useEffect(() => {
     if (showCreationSuccess) {
@@ -173,12 +196,32 @@ export function StudioView({
                     </TextField.Slot>
                   </TextField.Root>
                 </div>
-                <div className="flex items-center gap-2 self-end md:self-auto">
+                <div className="flex items-center gap-4 self-end md:self-auto">
                   <FilterDropdown value={filter} onChange={onFilterChange} />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-xs text-[#92a9c9]">
+                        ⌘/Ctrl + Enter
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {translate("shortcuts.actions.run")}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
               </div>
               {isMyStudio && (
-                <div className="flex justify-end">
+                <div className="flex justify-end items-center gap-3">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-xs text-[#92a9c9] cursor-help">
+                        ⌘/Ctrl + N
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      {translate("shortcuts.actions.newChain")}
+                    </TooltipContent>
+                  </Tooltip>
                   <Button
                     variant="surface"
                     onClick={() => setIsCreateDialogOpen(true)}

--- a/components/ui/create-sequence.tsx
+++ b/components/ui/create-sequence.tsx
@@ -26,6 +26,7 @@ import { useBulkCreateFramesMutation } from "@/app/services/frames";
 import { useCreateSequenceMutation } from "@/app/services/sequences";
 import { translate } from "@/lib/i18n";
 import { SequenceCreationFormValues } from "@/app/types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 interface Props {
   onClose: () => void;
@@ -357,14 +358,27 @@ export function CreateSequenceForm({
                 <ArrowRight className="h-4 w-4" />
               </Button>
             ) : (
-              <Button
-                type="submit"
-                disabled={pageFrames.length <= 1}
-                loading={isSaving || isSequenceSaving}
-              >
-                <Cloud />
-                {translate("sequence.cta.publish")}
-              </Button>
+              <div className="flex items-center gap-3">
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="text-xs text-[#92a9c9] cursor-help">
+                      ⌘/Ctrl + Enter
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    {translate("shortcuts.actions.run")}
+                  </TooltipContent>
+                </Tooltip>
+                <Button
+                  type="submit"
+                  data-run-shortcut
+                  disabled={pageFrames.length <= 1}
+                  loading={isSaving || isSequenceSaving}
+                >
+                  <Cloud />
+                  {translate("sequence.cta.publish")}
+                </Button>
+              </div>
             )}
           </div>
         </form>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -85,18 +85,11 @@ const SidebarProvider = React.forwardRef<
 
     // Adds a keyboard shortcut to toggle the sidebar.
     React.useEffect(() => {
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (
-          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-          (event.metaKey || event.ctrlKey)
-        ) {
-          event.preventDefault();
-          toggleSidebar();
-        }
-      };
+      const handleToggle = () => toggleSidebar();
 
-      window.addEventListener("keydown", handleKeyDown);
-      return () => window.removeEventListener("keydown", handleKeyDown);
+      window.addEventListener("toggle-sidebar", handleToggle as EventListener);
+      return () =>
+        window.removeEventListener("toggle-sidebar", handleToggle as EventListener);
     }, [toggleSidebar]);
 
     // We add a state so that we can do data-state="expanded" or "collapsed".

--- a/hooks/useKeyboardShortcuts.ts
+++ b/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+type Modifier = "meta" | "ctrl" | "metaOrCtrl" | "alt" | "shift";
+
+export type KeyboardShortcut = {
+  key: string;
+  modifier?: Modifier;
+  allowInInput?: boolean;
+  enabled?: boolean;
+  preventDefault?: boolean;
+  onTrigger: (event: KeyboardEvent) => void;
+};
+
+type Options = {
+  enabled?: boolean;
+};
+
+export function useKeyboardShortcuts(
+  shortcuts: KeyboardShortcut[],
+  options?: Options
+) {
+  const normalizedShortcuts = useMemo(
+    () =>
+      shortcuts.map((shortcut) => ({
+        ...shortcut,
+        key: shortcut.key.toLowerCase(),
+      })),
+    [shortcuts]
+  );
+
+  useEffect(() => {
+    if (options?.enabled === false) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const activeElement = document.activeElement as HTMLElement | null;
+      const isInputElement = Boolean(
+        activeElement &&
+          (activeElement.tagName === "INPUT" ||
+            activeElement.tagName === "TEXTAREA" ||
+            activeElement.isContentEditable)
+      );
+
+      for (const shortcut of normalizedShortcuts) {
+        if (shortcut.enabled === false) continue;
+        if (isInputElement && !shortcut.allowInInput) continue;
+
+        const keyMatches = event.key.toLowerCase() === shortcut.key;
+        if (!keyMatches) continue;
+
+        const modifierMatches = (() => {
+          switch (shortcut.modifier) {
+            case "meta":
+              return event.metaKey;
+            case "ctrl":
+              return event.ctrlKey;
+            case "metaOrCtrl":
+              return event.metaKey || event.ctrlKey;
+            case "alt":
+              return event.altKey;
+            case "shift":
+              return event.shiftKey;
+            default:
+              return true;
+          }
+        })();
+
+        if (!modifierMatches) continue;
+
+        if (shortcut.preventDefault ?? true) {
+          event.preventDefault();
+        }
+
+        shortcut.onTrigger(event);
+        break;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [normalizedShortcuts, options?.enabled]);
+}
+
+export type ShortcutHint = {
+  keys: string[];
+  label: string;
+};

--- a/locales/en.json
+++ b/locales/en.json
@@ -153,6 +153,18 @@
       "title": "Unable To Load Sequences"
     }
   },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "description": "Speed up your workflow with quick keyboard access.",
+    "helpTooltip": "View keyboard shortcuts",
+    "actions": {
+      "newChain": "New chain",
+      "save": "Save",
+      "run": "Run",
+      "openHelp": "Open shortcuts help",
+      "toggleSidebar": "Toggle sidebar"
+    }
+  },
   "studio": {
     "total": "Total Sequences",
     "lastEdit": "Last Edited",


### PR DESCRIPTION
## Summary
- add a reusable keyboard shortcut hook and a global help modal accessible from the help icon or `?`
- wire shortcuts for new sequence creation, publishing, profile save, and sidebar toggling with contextual tooltips
- surface shortcut hints near create, run, and save actions plus new locale strings

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc360ba2083249cc52585cc4b34ac)