### PR TITLE
Add sequence follow controls and notifications

### DIFF
--- a/__tests__/api/sequence-follow.test.ts
+++ b/__tests__/api/sequence-follow.test.ts
@@ -1,0 +1,173 @@
+import followHandler from "@/pages/api/sequence/follow";
+import muteHandler from "@/pages/api/sequence/mute";
+import notificationsHandler from "@/pages/api/sequence/notifications";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { vi } from "vitest";
+
+const prismaMocks = vi.hoisted(() => ({
+  findSequence: vi.fn(),
+  upsertFollower: vi.fn(),
+  deleteFollower: vi.fn(),
+  findFollower: vi.fn(),
+  countFollowers: vi.fn(),
+  findNotifications: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    sequence: {
+      findFirst: prismaMocks.findSequence,
+    },
+    sequenceFollower: {
+      upsert: prismaMocks.upsertFollower,
+      deleteMany: prismaMocks.deleteFollower,
+      findUnique: prismaMocks.findFollower,
+      count: prismaMocks.countFollowers,
+    },
+    sequenceNotification: {
+      findMany: prismaMocks.findNotifications,
+    },
+  },
+}));
+
+const sessionMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    session: {},
+    userId: 42,
+  }))
+);
+
+vi.mock("@/lib/api/auth", () => ({
+  requireApiSession: (...args: unknown[]) => sessionMock(...args),
+}));
+
+const createMockResponse = () => {
+  const store: { status?: number; body?: unknown } = {};
+  const res = {
+    status(code: number) {
+      store.status = code;
+      return res as NextApiResponse;
+    },
+    json(data: unknown) {
+      store.body = data;
+      return res as NextApiResponse;
+    },
+  } as unknown as NextApiResponse;
+
+  return { res, store };
+};
+
+describe("sequence follow and notification endpoints", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionMock.mockResolvedValue({ session: {}, userId: 42 });
+  });
+
+  it("follows a sequence and returns follower state", async () => {
+    prismaMocks.findSequence.mockResolvedValueOnce({ id: 9, isDeleted: false });
+    prismaMocks.findFollower.mockResolvedValueOnce({ muted: false });
+    prismaMocks.countFollowers.mockResolvedValueOnce(1);
+
+    const req = {
+      method: "POST",
+      body: { sequenceId: "9", action: "follow" },
+    } as unknown as NextApiRequest;
+    const { res, store } = createMockResponse();
+
+    await followHandler(req, res);
+
+    expect(store.status).toBe(200);
+    expect(prismaMocks.upsertFollower).toHaveBeenCalledWith({
+      where: { sequenceId_userId: { sequenceId: 9, userId: 42 } },
+      update: { muted: false },
+      create: { sequenceId: 9, userId: 42, muted: false },
+    });
+    expect(store.body).toMatchObject({
+      followerCount: 1,
+      isFollower: true,
+      isMuted: false,
+    });
+  });
+
+  it("unfollows a sequence", async () => {
+    prismaMocks.findSequence.mockResolvedValueOnce({ id: 10, isDeleted: false });
+    prismaMocks.findFollower.mockResolvedValueOnce(null);
+    prismaMocks.countFollowers.mockResolvedValueOnce(0);
+
+    const req = {
+      method: "POST",
+      body: { sequenceId: "10", action: "unfollow" },
+    } as unknown as NextApiRequest;
+    const { res, store } = createMockResponse();
+
+    await followHandler(req, res);
+
+    expect(store.status).toBe(200);
+    expect(prismaMocks.deleteFollower).toHaveBeenCalledWith({
+      where: { sequenceId: 10, userId: 42 },
+    });
+    expect(store.body).toMatchObject({
+      followerCount: 0,
+      isFollower: false,
+      isMuted: false,
+    });
+  });
+
+  it("mutes a followed sequence", async () => {
+    prismaMocks.findSequence.mockResolvedValueOnce({ id: 11, isDeleted: false });
+    prismaMocks.countFollowers.mockResolvedValueOnce(2);
+    prismaMocks.upsertFollower.mockResolvedValueOnce({ muted: true });
+
+    const req = {
+      method: "POST",
+      body: { sequenceId: "11", muted: true },
+    } as unknown as NextApiRequest;
+    const { res, store } = createMockResponse();
+
+    await muteHandler(req, res);
+
+    expect(store.status).toBe(200);
+    expect(store.body).toMatchObject({
+      followerCount: 2,
+      isFollower: true,
+      isMuted: true,
+    });
+    expect(prismaMocks.upsertFollower).toHaveBeenCalledWith({
+      where: { sequenceId_userId: { sequenceId: 11, userId: 42 } },
+      update: { muted: true },
+      create: { sequenceId: 11, userId: 42, muted: true },
+    });
+  });
+
+  it("returns notifications for the viewer", async () => {
+    const fakeNotifications = [
+      {
+        id: 1,
+        sequenceId: 11,
+        message: "Steps updated",
+        type: "STEPS_UPDATED",
+        read: false,
+        createdAt: "2024-05-05T00:00:00.000Z",
+        sequence: { id: 11, title: "Daily flow" },
+      },
+    ];
+    prismaMocks.findNotifications.mockResolvedValueOnce(fakeNotifications);
+
+    const req = {
+      method: "GET",
+      query: { sequenceId: "11" },
+    } as unknown as NextApiRequest;
+    const { res, store } = createMockResponse();
+
+    await notificationsHandler(req, res);
+
+    expect(store.status).toBe(200);
+    expect(store.body).toEqual(fakeNotifications);
+    expect(prismaMocks.findNotifications).toHaveBeenCalledWith({
+      where: { recipientId: 42, sequenceId: 11 },
+      include: { sequence: { select: { id: true, title: true } } },
+      orderBy: { createdAt: "desc" },
+      take: 50,
+    });
+  });
+});

--- a/__tests__/api/sequence.test.ts
+++ b/__tests__/api/sequence.test.ts
@@ -68,8 +68,15 @@ const mocks = vi.hoisted(() => {
     { id: 4, content: "Frame 4" },
     { id: 5, content: "Frame 5" },
   ]);
+  const findFollowersMock = vi.fn(async () => []);
 
-  return { createMock, findManyMock, findFirstMock, findManyFramesMock };
+  return {
+    createMock,
+    findManyMock,
+    findFirstMock,
+    findManyFramesMock,
+    findFollowersMock,
+  };
 });
 
 vi.mock("@/lib/prisma", () => ({
@@ -81,6 +88,9 @@ vi.mock("@/lib/prisma", () => ({
     },
     frame: {
       findMany: mocks.findManyFramesMock,
+    },
+    sequenceFollower: {
+      findMany: mocks.findFollowersMock,
     },
   },
 }));
@@ -229,9 +239,12 @@ describe("api/sequence endpoints", () => {
     expect(store.status).toBe(200);
     const json = store.body as { frames: unknown[] };
     expect(json.frames).toHaveLength(2);
-    expect(mocks.findFirstMock).toHaveBeenCalledWith({
-      where: { id: 5, isDeleted: false },
-    });
+    expect(mocks.findFirstMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 5, isDeleted: false },
+        include: expect.any(Object),
+      })
+    );
     expect(mocks.findManyFramesMock).toHaveBeenCalledTimes(1);
   });
 

--- a/app/types.ts
+++ b/app/types.ts
@@ -27,6 +27,8 @@ export interface Sequence {
   isDeleted: boolean;
   createdAt: string;
   updatedAt: string;
+  followers?: SequenceFollower[];
+  followerCount?: number;
 }
 
 export interface Frame {
@@ -41,7 +43,36 @@ export interface Frame {
 
 export interface SingleSequence extends Sequence {
   frames: Frame[];
+  viewerState?: {
+    isFollower: boolean;
+    isMuted: boolean;
+  };
 }
+
+export type SequenceFollower = {
+  id: number;
+  username: string;
+  avatarUrl?: string | null;
+  muted: boolean;
+};
+
+export type SequenceNotification = {
+  id: number;
+  sequenceId: number;
+  type: NotificationKind;
+  message: string;
+  read: boolean;
+  createdAt: string;
+  sequence?: {
+    id: number;
+    title: string;
+  };
+};
+
+export type NotificationKind =
+  | "STEPS_UPDATED"
+  | "NOTE_ADDED"
+  | "MILESTONE_MARKED";
 
 export type Visibility = "PUBLIC" | "PRIVATE" | "FRIENDS_ONLY";
 

--- a/components/view-sequence.tsx
+++ b/components/view-sequence.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import { useState } from "react";
-import { X } from "lucide-react";
+import { Bell, BellOff, UserCheck, Users, X } from "lucide-react";
 import { Carousel } from "@/components/ui/carousel";
-import { useGetSequenceByIdQuery } from "@/app/services/sequences";
+import {
+  useFollowSequenceMutation,
+  useGetSequenceByIdQuery,
+  useGetSequenceNotificationsQuery,
+  useMuteSequenceMutation,
+} from "@/app/services/sequences";
 import { translate } from "@/lib/i18n";
 import { Modal } from "./ui/modal";
 import { SequenceFrame } from "./sequence-card";
 import { skipToken } from "@reduxjs/toolkit/query";
+import { Badge, Button, Callout, Flex, Spinner, Text } from "@radix-ui/themes";
+import { useSession } from "next-auth/react";
 
 interface Props {
   sequenceId: string | number | null;
@@ -16,13 +23,52 @@ interface Props {
 
 export function ViewSequence({ sequenceId, onClose }: Props) {
   const [activeFrame, setActiveFrame] = useState(0);
-  const { data, isFetching, isError } = useGetSequenceByIdQuery(
+  const { data, isFetching, isError, refetch } = useGetSequenceByIdQuery(
     sequenceId ?? skipToken
   );
+  const { data: session } = useSession();
+  const viewerId = session?.user?.id ? parseInt(session.user.id, 10) : null;
+  const isAuthor = viewerId === data?.userId;
+  const [followSequence, { isLoading: isSavingFollow }] =
+    useFollowSequenceMutation();
+  const [muteSequence, { isLoading: isSavingMute }] = useMuteSequenceMutation();
+  const notificationsQueryArg =
+    sequenceId && viewerId ? { sequenceId } : skipToken;
+  const {
+    data: notifications,
+    isFetching: isFetchingNotifications,
+  } = useGetSequenceNotificationsQuery(notificationsQueryArg);
   const guardedFrames = data?.frames ?? [];
+  const followerCount = data?.followerCount ?? data?.followers?.length ?? 0;
+  const followers = data?.followers ?? [];
+  const isFollower = Boolean(data?.viewerState?.isFollower);
+  const isMuted = Boolean(data?.viewerState?.isMuted);
 
   const handleDialogChange = (open: boolean) => {
     if (!open) onClose();
+  };
+
+  const canInteractWithFollowers =
+    Boolean(viewerId) && !Number.isNaN(viewerId) && !isAuthor;
+
+  const handleFollowToggle = async () => {
+    if (!sequenceId || !canInteractWithFollowers) return;
+
+    await followSequence({
+      sequenceId,
+      action: isFollower ? "unfollow" : "follow",
+    }).unwrap();
+    await refetch();
+  };
+
+  const handleMuteToggle = async () => {
+    if (!sequenceId || !canInteractWithFollowers) return;
+
+    await muteSequence({
+      sequenceId,
+      muted: !isMuted,
+    }).unwrap();
+    await refetch();
   };
 
   if (!sequenceId) return null;
@@ -41,7 +87,73 @@ export function ViewSequence({ sequenceId, onClose }: Props) {
           </Modal.Close>
         </div>
         {!isFetching && !isError && (
-          <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2 rounded-lg border border-[#233348] bg-[#0f1723] p-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-amber-100">
+                  <Users className="h-4 w-4" aria-hidden="true" />
+                  <Text size="2" weight="bold">
+                    {followerCount} follower{followerCount === 1 ? "" : "s"}
+                  </Text>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    onClick={handleFollowToggle}
+                    disabled={!canInteractWithFollowers || isSavingFollow}
+                    variant={isFollower ? "surface" : "solid"}
+                    className="cursor-pointer"
+                  >
+                    {isSavingFollow ? (
+                      <Spinner size="1" />
+                    ) : (
+                      <UserCheck className="h-4 w-4" aria-hidden="true" />
+                    )}
+                    {isFollower ? "Unfollow" : "Follow"}
+                  </Button>
+                  <Button
+                    onClick={handleMuteToggle}
+                    disabled={
+                      !canInteractWithFollowers || !isFollower || isSavingMute
+                    }
+                    variant="ghost"
+                    className="cursor-pointer"
+                  >
+                    {isSavingMute ? (
+                      <Spinner size="1" />
+                    ) : isMuted ? (
+                      <BellOff className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                      <Bell className="h-4 w-4" aria-hidden="true" />
+                    )}
+                    {isMuted ? "Unmute" : "Mute"}
+                  </Button>
+                </div>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {followers?.slice(0, 6).map((follower) => (
+                  <Badge
+                    key={follower.id}
+                    color={follower.muted ? "gray" : "blue"}
+                    variant="surface"
+                  >
+                    {follower.username}
+                    {follower.muted ? " (muted)" : ""}
+                  </Badge>
+                ))}
+                {followers && followerCount > 6 && (
+                  <Text size="1" className="text-[#92a9c9]">
+                    +{followerCount - 6} more
+                  </Text>
+                )}
+              </div>
+              {!canInteractWithFollowers && (
+                <Text size="1" className="text-[#92a9c9]">
+                  {isAuthor
+                    ? "You own this sequence."
+                    : "Sign in to follow or mute this sequence."}
+                </Text>
+              )}
+            </div>
             <div className="text-xs text-amber-100">
               <span className="font-semibold uppercase tracking-wide">
                 {translate("frame.selfs")}
@@ -83,6 +195,40 @@ export function ViewSequence({ sequenceId, onClose }: Props) {
                 setActiveFrame((current) => Math.max(current - 1, 0))
               }
             />
+            {viewerId && notifications && notifications.length > 0 && (
+              <div className="mt-2 rounded-lg border border-[#233348] bg-[#0f1723] p-3">
+                <Flex align="center" justify="between" gap="2" mb="2">
+                  <Text size="2" weight="bold" className="text-white">
+                    Notifications
+                  </Text>
+                  {isFetchingNotifications && <Spinner size="1" />}
+                </Flex>
+                <div className="flex flex-col gap-2 max-h-48 overflow-y-auto">
+                  {notifications.map((notification) => (
+                    <Callout.Root
+                      key={notification.id}
+                      size="1"
+                      color="blue"
+                      variant="surface"
+                    >
+                      <Callout.Text className="text-sm text-white">
+                        {notification.message}
+                      </Callout.Text>
+                      <Callout.Text className="text-xs text-[#92a9c9]">
+                        {new Date(notification.createdAt).toLocaleString()}
+                      </Callout.Text>
+                    </Callout.Root>
+                  ))}
+                </div>
+                {isMuted && (
+                  <Callout.Root className="mt-2" color="gray" variant="surface">
+                    <Callout.Text className="text-xs text-[#92a9c9]">
+                      Notifications are muted for this sequence.
+                    </Callout.Text>
+                  </Callout.Root>
+                )}
+              </div>
+            )}
           </div>
         )}
       </Modal.Content>

--- a/pages/api/sequence/[id].ts
+++ b/pages/api/sequence/[id].ts
@@ -1,5 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth-options";
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,17 +18,66 @@ export default async function handler(
       return res.status(400).json({ message: "Sequence id is required" });
     }
 
+    let viewerId: number | null = null;
+    try {
+      const viewerSession = await getServerSession(req, res, authOptions);
+      viewerId = viewerSession?.user?.id
+        ? parseInt(viewerSession.user.id, 10)
+        : null;
+    } catch {
+      viewerId = null;
+    }
+
     const sequence = await prisma.sequence.findFirst({
       where: id ? { id: sequenceId, isDeleted: false } : { isDeleted: false },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            avatarUrl: true,
+          },
+        },
+      },
     });
     if (!sequence)
       return res.status(404).json({ message: "Sequence not found" });
+
+    const followerRecords = await prisma.sequenceFollower.findMany({
+      where: { sequenceId },
+      include: {
+        user: {
+          select: { id: true, username: true, avatarUrl: true },
+        },
+      },
+    });
+    const followers = followerRecords.map((record) => ({
+      id: record.user.id,
+      username: record.user.username,
+      avatarUrl: record.user.avatarUrl,
+      muted: record.muted,
+    }));
+    const viewerFollower = followerRecords.find(
+      (record) => record.userId === viewerId
+    );
 
     const frames = await prisma.frame.findMany({
       where: { id: { in: sequence.FrameOrder } },
     });
 
-    res.status(200).json({ ...sequence, frames });
+    res.status(200).json({
+      ...sequence,
+      frames,
+      followers,
+      followerCount: followers.length,
+      viewerState:
+        viewerId && !Number.isNaN(viewerId)
+          ? {
+              isFollower: Boolean(viewerFollower),
+              isMuted: Boolean(viewerFollower?.muted),
+            }
+          : undefined,
+    });
   } catch (error) {
     if (error instanceof Error)
       res

--- a/pages/api/sequence/follow.ts
+++ b/pages/api/sequence/follow.ts
@@ -1,0 +1,61 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/lib/prisma";
+import { requireApiSession } from "@/lib/api/auth";
+
+type FollowAction = "follow" | "unfollow";
+
+const isValidAction = (action: unknown): action is FollowAction =>
+  action === "follow" || action === "unfollow";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST")
+    return res.status(405).json({ message: "Method not allowed" });
+
+  const sessionResult = await requireApiSession(req, res);
+  if (!sessionResult) return;
+
+  const { sequenceId, action } = req.body;
+  const parsedId = parseInt(sequenceId, 10);
+
+  if (Number.isNaN(parsedId) || !isValidAction(action)) {
+    return res
+      .status(400)
+      .json({ message: "sequenceId and valid action are required" });
+  }
+
+  const sequence = await prisma.sequence.findFirst({
+    where: { id: parsedId, isDeleted: false },
+  });
+
+  if (!sequence) {
+    return res.status(404).json({ message: "Sequence not found" });
+  }
+
+  if (action === "follow") {
+    await prisma.sequenceFollower.upsert({
+      where: { sequenceId_userId: { sequenceId: parsedId, userId: sessionResult.userId } },
+      update: { muted: false },
+      create: { sequenceId: parsedId, userId: sessionResult.userId, muted: false },
+    });
+  } else {
+    await prisma.sequenceFollower.deleteMany({
+      where: { sequenceId: parsedId, userId: sessionResult.userId },
+    });
+  }
+
+  const followerRecord = await prisma.sequenceFollower.findUnique({
+    where: { sequenceId_userId: { sequenceId: parsedId, userId: sessionResult.userId } },
+  });
+  const followerCount = await prisma.sequenceFollower.count({
+    where: { sequenceId: parsedId },
+  });
+
+  res.status(200).json({
+    followerCount,
+    isFollower: Boolean(followerRecord),
+    isMuted: Boolean(followerRecord?.muted),
+  });
+}

--- a/pages/api/sequence/mute.ts
+++ b/pages/api/sequence/mute.ts
@@ -1,0 +1,47 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/lib/prisma";
+import { requireApiSession } from "@/lib/api/auth";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "POST")
+    return res.status(405).json({ message: "Method not allowed" });
+
+  const sessionResult = await requireApiSession(req, res);
+  if (!sessionResult) return;
+
+  const { sequenceId, muted } = req.body;
+  const parsedId = parseInt(sequenceId, 10);
+
+  if (Number.isNaN(parsedId) || typeof muted !== "boolean") {
+    return res
+      .status(400)
+      .json({ message: "sequenceId and muted flag are required" });
+  }
+
+  const sequence = await prisma.sequence.findFirst({
+    where: { id: parsedId, isDeleted: false },
+  });
+
+  if (!sequence) {
+    return res.status(404).json({ message: "Sequence not found" });
+  }
+
+  const follower = await prisma.sequenceFollower.upsert({
+    where: { sequenceId_userId: { sequenceId: parsedId, userId: sessionResult.userId } },
+    update: { muted },
+    create: { sequenceId: parsedId, userId: sessionResult.userId, muted },
+  });
+
+  const followerCount = await prisma.sequenceFollower.count({
+    where: { sequenceId: parsedId },
+  });
+
+  res.status(200).json({
+    followerCount,
+    isFollower: true,
+    isMuted: follower.muted,
+  });
+}

--- a/pages/api/sequence/notifications.ts
+++ b/pages/api/sequence/notifications.ts
@@ -1,0 +1,40 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import prisma from "@/lib/prisma";
+import { requireApiSession } from "@/lib/api/auth";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== "GET")
+    return res.status(405).json({ message: "Method not allowed" });
+
+  const sessionResult = await requireApiSession(req, res);
+  if (!sessionResult) return;
+
+  const { sequenceId } = req.query;
+  const parsedId = sequenceId ? parseInt(sequenceId as string, 10) : null;
+
+  if (sequenceId && Number.isNaN(parsedId)) {
+    return res.status(400).json({ message: "sequenceId must be numeric" });
+  }
+
+  const notifications = await prisma.sequenceNotification.findMany({
+    where: {
+      recipientId: sessionResult.userId,
+      ...(parsedId ? { sequenceId: parsedId } : {}),
+    },
+    include: {
+      sequence: {
+        select: {
+          id: true,
+          title: true,
+        },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+    take: 50,
+  });
+
+  res.status(200).json(notifications);
+}

--- a/pages/api/sequence/read.ts
+++ b/pages/api/sequence/read.ts
@@ -1,5 +1,7 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth-options";
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,17 +18,66 @@ export default async function handler(
       return res.status(400).json({ message: "Sequence id is required" });
     }
 
+    let viewerId: number | null = null;
+    try {
+      const viewerSession = await getServerSession(req, res, authOptions);
+      viewerId = viewerSession?.user?.id
+        ? parseInt(viewerSession.user.id, 10)
+        : null;
+    } catch {
+      viewerId = null;
+    }
+
     const sequence = await prisma.sequence.findFirst({
       where: id ? { id: sequenceId, isDeleted: false } : { isDeleted: false },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            avatarUrl: true,
+          },
+        },
+      },
     });
     if (!sequence)
       return res.status(404).json({ message: "Sequence not found" });
+
+    const followerRecords = await prisma.sequenceFollower.findMany({
+      where: { sequenceId },
+      include: {
+        user: {
+          select: { id: true, username: true, avatarUrl: true },
+        },
+      },
+    });
+    const followers = followerRecords.map((record) => ({
+      id: record.user.id,
+      username: record.user.username,
+      avatarUrl: record.user.avatarUrl,
+      muted: record.muted,
+    }));
+    const viewerFollower = followerRecords.find(
+      (record) => record.userId === viewerId
+    );
 
     const frames = await prisma.frame.findMany({
       where: { id: { in: sequence.FrameOrder } },
     });
 
-    res.status(200).json({ ...sequence, frames });
+    res.status(200).json({
+      ...sequence,
+      frames,
+      followers,
+      followerCount: followers.length,
+      viewerState:
+        viewerId && !Number.isNaN(viewerId)
+          ? {
+              isFollower: Boolean(viewerFollower),
+              isMuted: Boolean(viewerFollower?.muted),
+            }
+          : undefined,
+    });
   } catch (error) {
     if (error instanceof Error)
       res

--- a/pages/api/sequence/update.ts
+++ b/pages/api/sequence/update.ts
@@ -2,6 +2,32 @@ import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
 import { requireApiSession } from "@/lib/api/auth";
 
+type NotificationPayload = {
+  changeType?: "steps" | "note" | "milestone";
+  noteSummary?: string;
+  milestoneLabel?: string;
+};
+
+const buildNotificationMessage = (
+  type: NotificationPayload["changeType"],
+  sequenceTitle: string,
+  payload: NotificationPayload
+) => {
+  if (type === "steps") {
+    return `Steps updated in "${sequenceTitle}".`;
+  }
+
+  if (type === "note") {
+    return `New note added to "${sequenceTitle}"${payload.noteSummary ? `: ${payload.noteSummary}` : "."}`;
+  }
+
+  if (type === "milestone") {
+    return `Milestone reached in "${sequenceTitle}"${payload.milestoneLabel ? `: ${payload.milestoneLabel}` : "."}`;
+  }
+
+  return null;
+};
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -13,14 +39,77 @@ export default async function handler(
   if (!sessionResult) return;
 
   const { id } = req.query;
-  // description, visibility
-  const { isDeleted, title } = req.body;
+  const { isDeleted, title, description, changeType, noteSummary, milestoneLabel } =
+    req.body as NotificationPayload & {
+      isDeleted?: boolean;
+      title?: string;
+      description?: string;
+    };
+
+  const sequenceId = parseInt(id as string, 10);
+
+  if (Number.isNaN(sequenceId)) {
+    return res.status(400).json({ message: "Sequence id is required" });
+  }
 
   try {
-    const updatedSequence = await prisma.sequence.update({
-      where: { id: parseInt(id as string, 10) },
-      data: { isDeleted, ...(title ? { title } : {}) },
+    const existingSequence = await prisma.sequence.findUnique({
+      where: { id: sequenceId },
     });
+
+    if (!existingSequence || existingSequence.isDeleted) {
+      return res.status(404).json({ message: "Sequence not found" });
+    }
+
+    if (existingSequence.userId !== sessionResult.userId) {
+      return res.status(403).json({ message: "Forbidden" });
+    }
+
+    const updatedSequence = await prisma.sequence.update({
+      where: { id: sequenceId },
+      data: {
+        ...(typeof isDeleted === "boolean" ? { isDeleted } : {}),
+        ...(title ? { title } : {}),
+        ...(description !== undefined ? { description } : {}),
+      },
+    });
+
+    if (changeType) {
+      const notificationMessage = buildNotificationMessage(
+        changeType,
+        updatedSequence.title,
+        { changeType, noteSummary, milestoneLabel }
+      );
+
+      if (notificationMessage) {
+        const followers = await prisma.sequenceFollower.findMany({
+          where: {
+            sequenceId,
+            muted: false,
+            userId: { not: sessionResult.userId },
+          },
+        });
+
+        if (followers.length > 0) {
+          const notificationType =
+            changeType === "steps"
+              ? "STEPS_UPDATED"
+              : changeType === "note"
+                ? "NOTE_ADDED"
+                : "MILESTONE_MARKED";
+
+          await prisma.sequenceNotification.createMany({
+            data: followers.map((follower) => ({
+              sequenceId,
+              recipientId: follower.userId,
+              type: notificationType,
+              message: notificationMessage,
+            })),
+          });
+        }
+      }
+    }
+
     res.status(200).json(updatedSequence);
   } catch (error) {
     if (error instanceof Error)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model User {
   Sequences Sequence[]
   stories   Story[]
   contacts  Contact[]
+  followers SequenceFollower[]
+  notifications SequenceNotification[] @relation("NotificationRecipient")
 }
 
 model Sequence {
@@ -34,6 +36,8 @@ model Sequence {
   isDeleted   Boolean    @default(false)
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
+  followers   SequenceFollower[]
+  notifications SequenceNotification[]
 
   @@index([description, userId])
   @@index([title, userId])
@@ -74,6 +78,36 @@ model Contact {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model SequenceFollower {
+  id         Int      @id @default(autoincrement())
+  sequenceId Int
+  userId     Int
+  muted      Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  sequence Sequence @relation(fields: [sequenceId], references: [id])
+  user     User     @relation(fields: [userId], references: [id])
+
+  @@unique([sequenceId, userId])
+  @@index([userId])
+}
+
+model SequenceNotification {
+  id          Int                @id @default(autoincrement())
+  sequenceId  Int
+  recipientId Int
+  type        NotificationType
+  message     String
+  read        Boolean            @default(false)
+  createdAt   DateTime           @default(now())
+
+  sequence  Sequence @relation(fields: [sequenceId], references: [id])
+  recipient User     @relation("NotificationRecipient", fields: [recipientId], references: [id])
+
+  @@index([recipientId, read])
 }
 
 // model BrowsingHistory {
@@ -151,4 +185,10 @@ enum Role {
 enum Engine {
   CHESS
   GO
+}
+
+enum NotificationType {
+  STEPS_UPDATED
+  NOTE_ADDED
+  MILESTONE_MARKED
 }


### PR DESCRIPTION
## Summary
- add database relations and API endpoints to follow, unfollow, mute, and notify sequence followers
- enhance the sequence detail view with follow/unfollow toggles, mute controls, follower badges, and inline notifications
- extend RTK Query services and API tests to cover new follow/mute/notification flows

## Testing
- npx vitest __tests__/api/sequence-follow.test.ts __tests__/api/sequence-ownership.test.ts __tests__/api/sequence.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd00066308324b72ad0b680defcf6)